### PR TITLE
fix: skip alerts w/o CVEs

### DIFF
--- a/action.ps1
+++ b/action.ps1
@@ -177,8 +177,8 @@ else {
     $epssHash = @{}
     $epss | ForEach-Object { $epssHash[$_.cve] = $_ }
 
-
-    $Dependabot_Alerts_CVEs | ForEach-Object {
+    #Match EPSS scores to Dependabot Alerts CVEs, skip those without CVEs
+    $Dependabot_Alerts_CVEs | Where-Object { $_.security_advisory.cve_id }| ForEach-Object {
         $epssInfo = $epssHash[$_.security_advisory.cve_id]
         $scoring = New-Object PSObject -Property @{
             cve              = $epssInfo.cve


### PR DESCRIPTION
This pull request makes a small improvement to the way CVEs are matched between Dependabot alerts and EPSS scores in `action.ps1`. The change ensures that only alerts with valid CVE IDs are processed, which helps prevent errors and improves data accuracy.

* Improved data integrity: Updated the CVE matching logic to skip Dependabot alerts that do not have a CVE ID, ensuring only valid CVEs are processed.

Resolves situation such as this:
```shell
Org/repo Dependabot Alert Count: 76 (1 with no CVE)

ForEach-Object: /home/runner/work/_actions/advanced-security/dependabot-epss-action/v0.4/action.ps1:181
Line |
 181 |      $Dependabot_Alerts_CVEs | ForEach-Object {
     |                                ~~~~~~~~~~~~~~~~
     | Index operation failed; the array index evaluated to null.
Error: Process completed with exit code 1.
```